### PR TITLE
[Reviewer: Andy] Fix tap mutate flags endianess

### DIFF
--- a/daemon/memcached.c
+++ b/daemon/memcached.c
@@ -2442,7 +2442,8 @@ static void ship_tap_log(conn *c) {
                 bodylen += info.nbytes;
             }
             msg.mutation.message.header.request.bodylen = htonl(bodylen);
-            msg.mutation.message.body.item.flags = htonl(info.flags);
+            /* flags is opaque and should not be byte swapped. */
+            msg.mutation.message.body.item.flags = info.flags;
             msg.mutation.message.body.item.expiration = htonl(info.exptime);
             msg.mutation.message.body.tap.enginespecific_length = htons(nengine);
             msg.mutation.message.body.tap.ttl = ttl;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+memcached (1.6.00-0clearwater0.2) precise; urgency=low
+
+  * Correct endianess of flags field on TAP_MUTATE messages.
+
+ -- Project Clearwater Maintainers <maintainers@projectclearwater.org>  Mon, 13 Apr 2015 18:22:30 +0100
+
 memcached (1.6.00-0clearwater0.1) precise; urgency=low
 
   * Don't start in a shell.


### PR DESCRIPTION
Make the flags on TAP_MUTATE messages have the same endianess as SET requests. Tested by doing a SET followed by a TAP_MUTATE and checking the endianess was correct using tcpdump. 
