### PR TITLE
[Reviewer: Andy] Make TAP_MUTATE expiration time absolute

### DIFF
--- a/daemon/memcached.c
+++ b/daemon/memcached.c
@@ -2444,7 +2444,7 @@ static void ship_tap_log(conn *c) {
             msg.mutation.message.header.request.bodylen = htonl(bodylen);
             /* flags is opaque and should not be byte swapped. */
             msg.mutation.message.body.item.flags = info.flags;
-            msg.mutation.message.body.item.expiration = htonl(info.exptime);
+            msg.mutation.message.body.item.expiration = htonl(abstime(info.exptime));
             msg.mutation.message.body.tap.enginespecific_length = htons(nengine);
             msg.mutation.message.body.tap.ttl = ttl;
             msg.mutation.message.body.tap.flags = htons(tap_flags);

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 memcached (1.6.00-0clearwater0.2) precise; urgency=low
 
   * Correct endianess of flags field on TAP_MUTATE messages.
+  * Correct expiration on TAP_MUTATE messages to be an absolute time (rather than being relative to server start).
 
  -- Project Clearwater Maintainers <maintainers@projectclearwater.org>  Mon, 13 Apr 2015 18:22:30 +0100
 


### PR DESCRIPTION
Another PR to correct TAP_MUTATE messages. The expiration of each item was being returned as the expiration time in seconds since the server start. This means that when the item is injected back into another memcached it expiry is set to a bit longer than the uptime of the source server. 

I've tested this by running call stress through a Sprout pair, and randomly killing a memcached once a second. Astaire stats report the number of keys resynced each time is steady, and about what I would expect. Calls are stable throughout. 
