### PR TITLE
[Reviewer: Andy] Force init script to be updated; remove /etc/default/memcached

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+memcached (1.6.00-0clearwater0.5) precise; urgency=low
+
+  * Rework handling of init scripts.
+
+ -- Project Clearwater Maintainers <maintainers@projectclearwater.org>  Mon, 28 Aug 2015 18:18:30 +0100
+
 memcached (1.6.00-0clearwater0.4) precise; urgency=low
 
   * Remove START_PREFIX from status command.

--- a/debian/memcached.default
+++ b/debian/memcached.default
@@ -1,2 +1,0 @@
-# Set this to no to disable memcached.
-ENABLE_MEMCACHED=yes

--- a/debian/memcached.install
+++ b/debian/memcached.install
@@ -1,0 +1,1 @@
+scripts/* /usr/share/memcached/scripts/

--- a/debian/memcached.postinst
+++ b/debian/memcached.postinst
@@ -33,6 +33,12 @@ configure)
             mkdir -p /etc
             cp /usr/share/memcached/memcached.conf.default /etc/memcached.conf
     fi
+
+    # Install /etc/init.d/memcached in the postinst, because clearwater-memcached previously edited
+    # it with a script, and now the Debian infrastructure won't change it.
+    cp /usr/share/memcached/scripts/memcached-init /etc/init.d/memcached
+    service memcached restart
+
     ;;
 esac
 

--- a/debian/memcached.postrm
+++ b/debian/memcached.postrm
@@ -16,4 +16,9 @@ fi
 
     rm -f /var/run/memcached.pid
 
+if [ "$1" = "deconfigure" ]
+    then
+    rm -f /etc/init.d/memcached
+fi
+
 #DEBHELPER#

--- a/debian/rules
+++ b/debian/rules
@@ -72,7 +72,6 @@ install: build
 	#install -d $(SCRIPTS)
 	install -m 744 $(CURDIR)/scripts/start-memcached $(SCRIPTS)
 	install -m 744 $(CURDIR)/scripts/memcached-tool $(SCRIPTS)
-	install -m 755 $(CURDIR)/scripts/memcached-init $(CURDIR)/debian/memcached.init
 
 
 # Build architecture-independent files here.

--- a/scripts/memcached-init
+++ b/scripts/memcached-init
@@ -38,7 +38,7 @@ set -e
 . /lib/lsb/init-functions
 
 # Edit /etc/default/memcached to change this.
-ENABLE_MEMCACHED=no
+ENABLE_MEMCACHED=yes
 test -r /etc/default/memcached && . /etc/default/memcached
 
 


### PR DESCRIPTION
Tested by appending to the end of /etc/init.d/memcached, then installing the Debian package and checking that /etc/init.d/memcached became pristine again.
