### PR TITLE
[Reviewer: Ellie] Add Debian produced files to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /aclocal.m4
 /autom4te.cache
 /breakdancer_testsuite.c
+/build-stamp
 /config.h
 /config.h.in
 /config.log

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,4 @@
+files
+memcached.debhelper.log
+memcached.substvars
+memcached/


### PR DESCRIPTION
Ellie,

memcached fails to rebuild with the following error:

```
gbp:error: You have uncommitted changes in your source tree:
gbp:error: HEAD detached at 298f23d
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	build-stamp
	debian/files
	debian/memcached.debhelper.log
	debian/memcached.substvars
	debian/memcached/
```

This should fix that - can you confirm you are happy?