### PR TITLE
[Reviewer: AJH] Deal with expiry time 0 when getting absolute time

### DIFF
--- a/daemon/memcached.c
+++ b/daemon/memcached.c
@@ -216,6 +216,7 @@ static rel_time_t realtime(const time_t exptime) {
  */
 static time_t abstime(const rel_time_t exptime)
 {
+    if (exptime == 0) return 0;
     return process_started + exptime;
 }
 


### PR DESCRIPTION
Expiry times are stored as times relative to when the process started:

https://github.com/Metaswitch/memcached/blob/clearwater-upstream/include/memcached/types.h#L71-L72

The abstime function doesn't deal with the case when expiry time is zero (no expiry). This fixes that.