### PR TITLE
[Reviewer: Richard] Fix up race condition in UTs

### DIFF
--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -187,8 +187,17 @@ sub new_memcached {
 
     # unix domain sockets
     if ($args =~ /-s (\S+)/) {
-        sleep 1;
         my $filename = $1;
+        for (my $i = 0; $i < 30; $i++) {
+            # Sleep for up to 30s waiting for the socket to exist
+            if ( -e $filename) {
+                # File exists, so break out
+                last;
+            }
+
+            sleep 1;
+        }
+
         my $conn = IO::Socket::UNIX->new(Peer => $filename) ||
             croak("Failed to connect to unix domain socket: $! '$filename'");
 


### PR DESCRIPTION
The memcached UTs could fail if we took a long time to start up the memcached process.
Previously, the UT would sleep for 1 second then try to connect to the unix socket, but this was not proving long enough sometimes. So I've added a loop that will sleep up to ~30s until the socket file exists. If it still doesn't exist after 30s we'll fail.

Tested that the build works with this fix.