### PR TITLE
[Reviewer: Seb] Add debug packages for memcached

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,4 +1,7 @@
 files
+memcached-dbg.debhelper.log
+memcached-dbg.substvars
+memcached-dbg/
 memcached.debhelper.log
 memcached.substvars
 memcached/

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+memcached (1.6.00-0clearwater0.6) precise; urgency=low
+
+  * Add debug package containing debug symbols
+
+ -- Project Clearwater Maintainers <maintainers@projectclearwater.org>  Tue, 19 Aug 2017 14:44:00 +0100
+
 memcached (1.6.00-0clearwater0.5) precise; urgency=low
 
   * Rework handling of init scripts.

--- a/debian/control
+++ b/debian/control
@@ -26,3 +26,10 @@ Description: A high-performance memory object caching system
  of the specific application. Traditionally this has been used in mod_perl
  apps to avoid storing large chunks of data in Apache memory, and to share
  this burden across several machines.
+
+Package: memcached-dbg
+Architecture: any
+Depends: memcached (= ${binary:Version})
+Section: debug
+Recommends: gdb
+Description: Debugging symbols for memcached

--- a/debian/control
+++ b/debian/control
@@ -32,4 +32,5 @@ Architecture: any
 Depends: memcached (= ${binary:Version})
 Section: debug
 Recommends: gdb
+Priority: extra
 Description: Debugging symbols for memcached

--- a/debian/rules
+++ b/debian/rules
@@ -90,7 +90,7 @@ binary-arch: build install
 	dh_installinit
 	dh_installman
 	dh_link
-	dh_strip
+	dh_strip --dbg-package=memcached-dbg
 	dh_compress
 	dh_fixperms
 	dh_installdeb


### PR DESCRIPTION
Seb,

Currently memcached doesn't produce debug symbols, which makes it difficult to diagnose crashes.

This adds a package to contain debug symbols, as per https://wiki.debian.org/DebugPackage