### PR TITLE
[Reviewer: AJH] Set dumpable flag to dump core

### DIFF
--- a/daemon/memcached.c
+++ b/daemon/memcached.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <sys/prctl.h>
 
 static inline void item_set_cas(const void *cookie, item *it, uint64_t cas) {
     settings.engine.v1->item_set_cas(settings.engine.v0, cookie, it, cas);
@@ -7369,6 +7370,11 @@ int main (int argc, char **argv) {
             settings.extensions.logger->log(EXTENSION_LOG_WARNING, NULL,
                     "failed to assume identity of user %s: %s\n", username,
                     strerror(errno));
+            exit(EX_OSERR);
+        }
+        if (prctl(PR_SET_DUMPABLE, 1) < 0) {
+            settings.extensions.logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "failed to set dumpable flag to ensure core dumps are possible");
             exit(EX_OSERR);
         }
     }

--- a/daemon/memcached.c
+++ b/daemon/memcached.c
@@ -7374,7 +7374,8 @@ int main (int argc, char **argv) {
         }
         if (prctl(PR_SET_DUMPABLE, 1) < 0) {
             settings.extensions.logger->log(EXTENSION_LOG_WARNING, NULL,
-                    "failed to set dumpable flag to ensure core dumps are possible");
+                    "failed to set dumpable flag to ensure core dumps are possible: %s\n",
+                    strerror(errno));
             exit(EX_OSERR);
         }
     }


### PR DESCRIPTION
Some background. A few months back, I thought I had enabled core dumps for memcached under Metaswitch/clearwater-infrastructure#481 by setting the `-r` option. I tested this in EC2 and it worked fine but we've not been seeing core dumps on openstack/vmware. This PR fixes that.

Memcached is started as root and switches to the memcache user once it's up using `setuid()`. There's configuration in Linux to set whether core dumps can be made by setuid programs. This is in `/proc/sys/fs/suid_dumpable`. This was set to 2 in EC2 and 0 in vmware/openstack which is why we were seeing different behaviour. It's not particularly safe to allow any setuid program to dump core, so the fix here is to set the dumpable flag once memcached switches user, so that core files can be dumped.

Tested by sending in SIGSEGV to the memcached process on a node and checking in strace that core was dumped, and then checking the diags directory for a core file. The live tests also pass.

A side effect of this is that is that the files under `/proc/<memcached_pid>` are now owned by the memcache user. I don't see a problem with this - it matches all the other processes.